### PR TITLE
Add kraft push command

### DIFF
--- a/kraft/cmd/__init__.py
+++ b/kraft/cmd/__init__.py
@@ -49,3 +49,4 @@ from .menuconfig import cmd_menuconfig
 from .run import cmd_run
 from .up import cmd_up
 from .package import cmd_package
+from .push import cmd_push

--- a/kraft/cmd/push.py
+++ b/kraft/cmd/push.py
@@ -35,7 +35,6 @@ from kraft.logger import logger
 import click
 import sys
 import os
-import subprocess
 import tarfile
 import json
 
@@ -64,25 +63,29 @@ default_passwd = 'Harbor12345'
 @click.option(
     '--server', '-s', 'server',
     help='Specify a Harbor instance url',
-    metavar="http://URL:PORT"
+    metavar="http://URL:PORT",
+    default=default_url
 )
 
 @click.option(
     '--project', '-p', 'project',
     help='Specify the project',
-    metavar="PROJECT"
+    metavar="PROJECT",
+    default=default_project
 )
 
 @click.option(
     '--user', '-u', 'user',
     help='Specify the user',
-    metavar="USER"
+    metavar="USER",
+    default=default_user
 )
 
 @click.option(
     '--password', '-pw', 'passwd',
     help='Specify the password',
-    metavar="PASSWORD"
+    metavar="PASSWORD",
+    default=default_passwd
 )
 
 @click.pass_context
@@ -92,11 +95,9 @@ def cmd_push(ctx, image=None, name=None, server=None, project=None, user=None, p
     """
 
     if image is None:
-        output = subprocess.check_output(['ls', default_path])
-        
-        files = output.decode('utf-8').split()
+        files = os.listdir(default_path)
         if len(files) != 1:
-            logger.critical('Operation failed, multiple files found.')
+            logger.critical('Operation failed, none or multiple files found.')
             if ctx.obj.verbose:
                 import traceback
                 logger.critical(traceback.format_exc())
@@ -107,18 +108,6 @@ def cmd_push(ctx, image=None, name=None, server=None, project=None, user=None, p
     if name is None:
         tokens = image.split('/')
         name = tokens[len(tokens)-1]
-
-    if server is None:
-        server = default_url
-
-    if project is None:
-        project = default_project
-
-    if user is None:
-        user = default_user
-
-    if passwd is None:
-        passwd = default_passwd
 
     try:
         kraft_push(
@@ -140,10 +129,8 @@ def cmd_push(ctx, image=None, name=None, server=None, project=None, user=None, p
 
 @click.pass_context
 def kraft_push(ctx, image=None, name=None, server=None, project=None, user=None, passwd=None):
-
-    cmd = 'ls ' + image + ' > /dev/null 2>&1'
-    rc = os.system(cmd)
-    if rc != 0:
+  
+    if not os.path.isfile(image):
         raise Exception('Image not found.')
 
     rc = tarfile.is_tarfile(image)

--- a/kraft/cmd/push.py
+++ b/kraft/cmd/push.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Authors: Laurentiu Barbulescu <lrbarbulescu@gmail.com>
+#
+# Copyright (c) 2021, NEC Europe Laboratories GmbH., NEC Corporation.
+#                     All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import click
+import sys
+import os
+import subprocess
+
+from kraft.logger import logger
+
+default_path = './package/'
+default_server = '10.16.4.30/library/'
+
+# TODO: add version tag for repositories
+@click.command('push', short_help='Push an OCI-Image on Harbor')
+
+@click.option(
+    '--image', '-i', 'image',
+    help='Specify the OCI-Image path. Default: ./package/*',
+    metavar="IMAGE"
+)
+
+@click.option(
+    '--name', '-n', 'name',
+    help='Specify the repository name. Default: IMAGE_NAME',
+    metavar="REPOSITORY"
+)
+
+@click.option(
+    '--server', '-s', 'server',
+    help='Specify the Harbor instance and project',
+    metavar="IP/PROJECT/"
+)
+
+@click.pass_context
+def cmd_push(ctx, image=None, name=None, server=None):
+    """
+    Push an OCI-Image on Harbor
+    """
+
+    if image is None:
+        output = subprocess.check_output(['ls', default_path]).decode('utf-8')
+        
+        files = output.split()
+        if len(files) != 1:
+            logger.critical('Operation failed, multiple files found.')
+            if ctx.obj.verbose:
+                import traceback
+                logger.critical(traceback.format_exc())
+            sys.exit(1)
+        else:
+            image = default_path + files[0]
+            if name is None:
+                name = files[0]
+    if server is None:
+        server = default_server
+
+    try:
+        kraft_push(
+            image=image,
+            name=name,
+            server=server
+        )
+    except Exception as e:
+        logger.critical(str(e))
+
+        if ctx.obj.verbose:
+            import traceback
+            logger.critical(traceback.format_exc())
+
+        sys.exit(1)
+
+@click.pass_context
+def kraft_push(ctx, image=None, name=None, server=None):
+
+    cmd = 'docker -v > /dev/null 2>&1'
+    rc = os.system(cmd)
+    if rc != 0:
+        raise Exception('Missing docker client.')
+
+    cmd = 'ls ' + image + ' > /dev/null 2>&1'
+    rc = os.system(cmd)
+    if rc != 0:
+        raise Exception('Image not found.')
+
+    cmd = 'file ' + image + ' | grep "tar archive" > /dev/null 2>&1'
+    rc = os.system(cmd)
+    if rc != 0:
+        raise Exception('Bad OCI-Image format.')
+
+    cmd = 'docker import ' + image + ' ' + name
+    os.system(cmd)
+
+    repo_name = server + name
+    cmd = 'docker tag ' + name + ' ' + repo_name + '> /dev/null 2>&1'
+    os.system(cmd)
+
+    cmd = 'docker push ' + repo_name
+    os.system(cmd)
+
+    cmd = 'docker rmi -f ' + name + ' ' + repo_name + '> /dev/null 2>&1'
+    os.system(cmd)

--- a/kraft/kraft.py
+++ b/kraft/kraft.py
@@ -44,6 +44,7 @@ from kraft.cmd import cmd_run
 from kraft.cmd import cmd_up
 from kraft.cmd import grp_lib
 from kraft.cmd import cmd_package
+from kraft.cmd import cmd_push
 from kraft.context import KraftContext
 from kraft.logger import logger
 from kraft.util.cli import CONTEXT_SETTINGS
@@ -111,3 +112,4 @@ kraft.add_command(cmd_run)
 kraft.add_command(cmd_clean)
 kraft.add_command(grp_lib)
 kraft.add_command(cmd_package)
+kraft.add_command(cmd_push)


### PR DESCRIPTION
This commit introduces the `kraft push` command.
It uses the vsoch reggie client to push the OCI-Image on Harbor and auto-detects the image if it's alone in the `./package` directory.